### PR TITLE
Enhancement/scoring logic

### DIFF
--- a/linksight/api/matchers/ngrams_matcher.py
+++ b/linksight/api/matchers/ngrams_matcher.py
@@ -104,14 +104,17 @@ class NgramsMatcher(BaseMatcher):
         if len(search_terms) > len(candidate_terms):
             score -= 30
 
-        # if the search terms have only one term, don't include the similarity
-        # score of the other terms.
-        if len(search_terms) > 1:
-            other_items_ratio = fuzz.ratio(
-                ' '.join(other_search_terms),
-                ' '.join(other_candidate_terms))
-            other_items_diff = 100 - other_items_ratio
-            score -= other_items_diff * other_items_ratio_weight
+        # for search terms with higher admin levels provided,
+        # score the similarity ratio of each higher admin level with its
+        # counterpart in the candidate higher admin levels
+
+        if (len(search_terms) > 1) and (expected_higher_adm_items > 0):
+            for i in range(0,len(other_search_terms)):
+                try:
+                    other_item_ratio = fuzz.ratio(other_search_terms[i],other_candidate_terms[i])
+                    score -= (100 - other_item_ratio) * (other_items_ratio_weight/len(other_search_terms))
+                except:
+                    pass
 
         return (
             candidate_tuple,

--- a/linksight/api/matchers/ngrams_matcher.py
+++ b/linksight/api/matchers/ngrams_matcher.py
@@ -78,8 +78,8 @@ class NgramsMatcher(BaseMatcher):
         (first_search_term, *other_search_terms) = search_terms
         (first_candidate_term, *other_candidate_terms) = candidate_terms
 
-        # everything starts with perfect score, then we penalize for differences
-        score = 100
+        # every fuzz match starts with score of 99, then we penalize for differences
+        score = 99
 
         # check on jw distance ratio between the very first items in search terms
         # and candidate terms. multiply by 100 since jellyfish returns a decimal
@@ -90,7 +90,7 @@ class NgramsMatcher(BaseMatcher):
         first_item_diff = 100 - first_item_ratio
         score -= first_item_diff * first_item_ratio_weight
 
-        # if a search and the candidate have the same administrative level,
+        # if a search and the candidate don't have the same administrative level,
         # inflict penalty
         if search_adm != candidate_adm:
             score -= 10
@@ -154,10 +154,12 @@ class NgramsMatcher(BaseMatcher):
         # matching on an candidate with only a single common n-gram with the
         # search terms
 
-        threshold = len(ss_ngrams) / 3
-        most_possible = [
-            k for k, v in Counter(possible_matches).items() if v >= threshold
-        ]
+        #threshold = len(ss_ngrams) / 3
+        #most_possible = [
+        #    k for k, v in Counter(possible_matches).items() if v >= threshold
+        #]
+
+        most_possible = set(possible_matches)
 
         # calculate similarity scores of search tuples with candidate among
         # possible matches for each unique psgc code, get the match phrase with

--- a/linksight/api/matchers/ngrams_matcher.py
+++ b/linksight/api/matchers/ngrams_matcher.py
@@ -95,6 +95,11 @@ class NgramsMatcher(BaseMatcher):
         if search_adm != candidate_adm:
             score -= 10
 
+        # penalize missing vs expected higher interlevels
+        expected_higher_adm_items = {'bgy':2,'municity':1,'prov':0}[search_adm]
+        missing_higher_items = expected_higher_adm_items - len(other_search_terms)
+        score -= missing_higher_items * ((other_items_ratio_weight*50)/expected_higher_adm_items)
+
         # if there are more search terms than candidate terms, inflict a penalty
         if len(search_terms) > len(candidate_terms):
             score -= 30


### PR DESCRIPTION
Slight improvements to scoring matcher:

I had to restore doing fuzzy matching on all unique possible matches, rather than only running fuzzy matching on candidates with a minimum 3 common n-grams with the search terms. We were missing out on some correct matches because of this threshold. 

Anyway, we implemented that threshold before to improve speed. But the speed is already faster now that we're using n-gram lengths of 3 and not 2. The trade off is that Linksight is not effective for matching misspelled location names of 3 or fewer characters. For example, it will not correctly identifying the barangay of "Aga, Delfin Albano" if this is misspelled as "Agm, Delfin Albano." But these cases are few and far between, so we can address later.

Other improvements:
- When there are blank interlevels in the search terms, we don't inflict a full penalty, but only a half penalty for each missing term. @syvlabs provided one example. Say you have two sets of search terms: `Poblacion, Liliw` and `Poblacion, Liliw, R`. When compared with candidate `Poblacion, Liliw, Laguna`, the former should score better than the latter. Why? By putting "R" as the third item, it become more likely that the user could be referring to totally different candidate. In contrast, simply leaving the third item blank is more open-ended.

- Before, we used to compute the similarity ratio between the concatenated secondary terms (or the higher administrative levels) in a search tuple and its candidate match. However, this caused the character length of secondary terms to incorrectly affect the score.  For example, when compared with the candidate `PIPIAS, BACARRA ILOCOS NORTE`, the search terms `PIPIAS, BACARRA` would score lower than `PIPIAS, ILOCOS NORTE.` This is because it requires more "edits" to turn `PIPIAS, BACARRA` into `PIPIAS, BACARRA, ILOCOS NORTE.`  This didn't make sense. Instead, we now separately calculate and weight the similarity between individual components of the search and candidate terms.